### PR TITLE
Do not require APPDATA

### DIFF
--- a/src/ccompass/CCMPS.py
+++ b/src/ccompass/CCMPS.py
@@ -34,6 +34,35 @@ os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"
 
 # -----------------------------------------------------------------------------------------------------------------------------
 
+import os
+import platform
+from pathlib import Path
+
+
+def get_data_directory() -> Path:
+    """Get the platform-specific data directory."""
+    system = platform.system()
+
+    if system == "Linux":
+        return Path(
+            os.getenv(
+                "XDG_DATA_HOME",
+                os.path.join(os.path.expanduser("~"), ".local", "share"),
+            )
+        )
+
+    if system == "Windows":
+        return Path(
+            os.getenv(
+                "APPDATA", os.path.join(os.path.expanduser("~"), "AppData", "Roaming")
+            )
+        )
+
+    if system == "Darwin":
+        return Path(os.path.expanduser("~"), "Library", "Application Support")
+
+    raise NotImplementedError(f"Unsupported platform: {system}")
+
 
 def main():
     fract_paths, fract_tables, fract_data, fract_pos = action.resetinput()

--- a/src/ccompass/MOP.py
+++ b/src/ccompass/MOP.py
@@ -19,17 +19,14 @@ import tensorflow as tf
 from tensorflow import keras
 import keras_tuner as kt
 import keras.backend as K
-
+from .CCMPS import get_data_directory
 # from tensorflow.keras.models import Model
 
 
 import os
 
-# Get the user's AppData directory
-appdata_directory = os.getenv("APPDATA")
-
-# Define the path to the 'Classifier_Models' folder within AppData
-classifier_directory = os.path.join(appdata_directory, "CCOMPASS_Models")
+# Define the path to the 'Classifier_Models' folder within the user's data directory
+classifier_directory = get_data_directory() / "CCOMPASS_Models"
 
 # Create the folder if it does not exist
 if not os.path.exists(classifier_directory):


### PR DESCRIPTION
Use platform-specific data-directories, so we can launch the programm on Linux without setting the APPDATA environment variable.

Closes #4.