### PR TITLE
Refactor and test create_markerlist

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,0 +1,41 @@
+"""Miscellaneous tests for the ccompass package."""
+
+import numpy as np
+import pandas as pd
+
+from ccompass.CCMPS import create_markerlist
+
+
+def test_create_markerlist():
+    marker_sets = {
+        "somefile": {
+            "class_col": "MarkerCompartment",
+            "classes": ["PROTEIN - COMPLEX", "CYTOPLASM", "LYSOSOME"],
+            "identifier_col": "Genename",
+            "table": pd.DataFrame(
+                {
+                    "Genename": ["AAGAB", "AAK1", "AARS1"],
+                    "MarkerCompartment": [
+                        "CYTOPLASM",
+                        "PROTEIN - COMPLEX",
+                        "CYTOPLASM",
+                    ],
+                }
+            ),
+        }
+    }
+    marker_conv = {
+        "PROTEIN - COMPLEX": "PROTEIN_COMPLEX",
+        "CYTOPLASM": "CYTOPLASM",
+        "LYSOSOME": "LYSOSOME",
+        "ignored...": np.nan,
+    }
+    marker_params = {"how": "exclude", "what": "unite"}
+    markerlist = create_markerlist(marker_sets, marker_conv, marker_params)
+    assert markerlist.to_dict() == {
+        "class": {
+            "AAGAB": "CYTOPLASM",
+            "AAK1": "PROTEIN_COMPLEX",
+            "AARS1": "CYTOPLASM",
+        }
+    }


### PR DESCRIPTION
* Fix pandas FutureWarning:

  > C-COMPASS/src/ccompass/CCMPS.py:2649: FutureWarning: A value is trying to be set on a copy of a DataFrame or Series through chained assignment using an inplace method.
  The behavior will change in pandas 3.0. This inplace method will never work because the intermediate object on which we are setting values always behaves as a copy.

  > For example, when doing 'df[col].method(value, inplace=True)', try using 'df.method({col: value}, inplace=True)' or df[col] = df[col].method(value) instead, to perform the operation inplace on the original object.

  >  mset[f"class{counter}"].replace(

* Simplify
* Add basic test