### PR TITLE
Replace deprecated DataFrame.applymap

### DIFF
--- a/src/ccompass/CCMPS.py
+++ b/src/ccompass/CCMPS.py
@@ -2438,9 +2438,9 @@ def tp_add(window, tp_paths, tp_tables, tp_indata, tp_pos, tp_identifiers):
         data = pd.read_csv(filename, sep="\t", header=0)
         data = data.replace("NaN", np.nan)
         data = data.replace("Filtered", np.nan)
-        data = data.applymap(convert_to_float)
+        data = data.map(convert_to_float)
 
-        rows_with_float = data.applymap(is_float).any(axis=1)
+        rows_with_float = data.map(is_float).any(axis=1)
         data = data[rows_with_float]
 
         colnames = data.columns.values.tolist()
@@ -2953,13 +2953,13 @@ def create_markerprofiles(fract_data, key, fract_info, marker_list):
         for condition in profiles:
             profiles[condition] = pd.merge(
                 profiles[condition],
-                fract_info[key].astype(str).applymap(str.upper),
+                fract_info[key].astype(str).map(str.upper),
                 left_index=True,
                 right_index=True,
             )
-            # profiles[condition] = pd.merge(profiles[condition], fract_info[key].applymap(str.upper), left_index = True, right_index = True)
+            # profiles[condition] = pd.merge(profiles[condition], fract_info[key].map(str.upper), left_index = True, right_index = True)
 
-            # fract_info_upper = fract_info[key].applymap(str.upper)
+            # fract_info_upper = fract_info[key].map(str.upper)
             fract_marker[condition] = (
                 pd.merge(
                     profiles[condition],

--- a/src/ccompass/MOA.py
+++ b/src/ccompass/MOA.py
@@ -165,7 +165,7 @@ def stats_proteome(learning_xyz, NN_params, fract_data, fract_conditions):
         ### ## add TPA:
         ### if mode == 'deep':
         ###     TPA_list = []
-        ###     tp_nontrans = tp_data[condition].applymap(lambda x: 2 ** x)
+        ###     tp_nontrans = tp_data[condition].map(lambda x: 2 ** x)
         ###     for replicate in tp_data[condition]:
         ###         TPA_list.append(tp_nontrans[replicate])
         ###     combined_TPA = pd.concat(TPA_list, axis = 1)
@@ -403,7 +403,7 @@ def stats_proteome(learning_xyz, NN_params, fract_data, fract_conditions):
         cc_sums = results[condition]["metrics"][cc_cols].sum(
             axis=1, skipna=True
         )
-        # cc_sums = results[condition]['metrics'][cc_cols].applymap(safe_sum)
+        # cc_sums = results[condition]['metrics'][cc_cols].map(safe_sum)
         results[condition]["metrics"][cc_cols] = results[condition]["metrics"][
             cc_cols
         ].div(cc_sums, axis=0)
@@ -799,7 +799,7 @@ def class_comparison(tp_data, fract_conditions, results, comparison):
         ## add TPA:
         TPA_list = []
         TPA_list = []
-        tp_nontrans = tp_data[condition].applymap(lambda x: 2**x)
+        tp_nontrans = tp_data[condition].map(lambda x: 2**x)
         for replicate in tp_data[condition]:
             TPA_list.append(tp_nontrans[replicate])
         combined_TPA = pd.concat(TPA_list, axis=1)

--- a/src/ccompass/MOP_stats.py
+++ b/src/ccompass/MOP_stats.py
@@ -98,7 +98,7 @@ def stats_exec3(
         ## add TPA:
         if mode == "deep":
             TPA_list = []
-            tp_nontrans = tp_data[condition].applymap(lambda x: 2**x)
+            tp_nontrans = tp_data[condition].map(lambda x: 2**x)
             for replicate in tp_data[condition]:
                 TPA_list.append(tp_nontrans[replicate])
             combined_TPA = pd.concat(TPA_list, axis=1)
@@ -331,7 +331,7 @@ def stats_exec3(
         cc_sums = results[condition]["metrics"][cc_cols].sum(
             axis=1, skipna=True
         )
-        # cc_sums = results[condition]['metrics'][cc_cols].applymap(safe_sum)
+        # cc_sums = results[condition]['metrics'][cc_cols].map(safe_sum)
         results[condition]["metrics"][cc_cols] = results[condition]["metrics"][
             cc_cols
         ].div(cc_sums, axis=0)
@@ -500,7 +500,7 @@ def stats_exec2(learning_xyz, NN_params, tp_data, fract_marker):
 
         # add TPA:
         TPA_list = []
-        tp_nontrans = tp_data[condition].applymap(lambda x: 2**x)
+        tp_nontrans = tp_data[condition].map(lambda x: 2**x)
         for replicate in tp_data[condition]:
             TPA_list.append(tp_nontrans[replicate])
 

--- a/src/ccompass/TPP.py
+++ b/src/ccompass/TPP.py
@@ -73,8 +73,8 @@ def create_dataset(
                         )
                         replicate += 1
 
-        if data_new.applymap(lambda x: "," in str(x)).any().any():
-            data_new = data_new.applymap(
+        if data_new.map(lambda x: "," in str(x)).any().any():
+            data_new = data_new.map(
                 lambda x: str(x).replace(",", ".") if isinstance(x, str) else x
             )
             data_new = data_new.apply(pd.to_numeric, errors="coerce")


### PR DESCRIPTION
Fixes, among others:
```
FutureWarning: DataFrame.applymap has been deprecated. Use DataFrame.map instead.
  fract_info[key].astype(str).applymap(str.upper),
```

Closes #43.