### PR TITLE
Fix marker option: `discrepancies` -> `exclude`

### DIFF
--- a/src/ccompass/marker_parameters_dialog.py
+++ b/src/ccompass/marker_parameters_dialog.py
@@ -93,7 +93,7 @@ def show_dialog(params_old: dict[str, Any]) -> dict[str, Any]:
             break
 
         if event == "--PMM_exclude--":
-            marker_params["how"] = "esclude"
+            marker_params["how"] = "exclude"
             window["--PMM_exclude--"].Update(value=True)
             window["--PMM_majority--"].Update(value=False)
         elif event == "--PMM_majority--":


### PR DESCRIPTION
Most likely, so far, this option didn't work as expected due to a typo.

Closes #85.