### PR TITLE
Make secondary windows modal

### DIFF
--- a/src/ccompass/FDP.py
+++ b/src/ccompass/FDP.py
@@ -542,7 +542,12 @@ def create_fract_processing_window() -> sg.Window:
             ),
         ]
     ]
-    return sg.Window("Processing...", layout_FDP, size=(600, 120))
+    return sg.Window(
+        "Processing...",
+        layout_FDP,
+        size=(600, 120),
+        modal=True,
+    )
 
 
 def start_fract_data_processing(

--- a/src/ccompass/RP.py
+++ b/src/ccompass/RP.py
@@ -40,6 +40,7 @@ def RP_gradient_heatmap(fract_data):
         layout,
         finalize=True,
         resizable=True,
+        modal=True,
     )
 
     # Custom colormap: from #f2f2f2 (for value 0) to #6d6e71 (for value 1)
@@ -174,6 +175,7 @@ def RP_stats_heatmap(results):
         layout,
         resizable=True,
         finalize=True,
+        modal=True,
     )
 
     # Custom colormap: from #f2f2f2 (for value 0) to #6d6e71 (for value 1)
@@ -320,7 +322,11 @@ def RP_stats_distribution(results):
 
     # Create the window with a static size
     window = sg.Window(
-        "Class Distribution Pie Chart", layout, resizable=True, finalize=True
+        "Class Distribution Pie Chart",
+        layout,
+        resizable=True,
+        finalize=True,
+        modal=True,
     )
 
     # Function to plot pie chart and return as a PIL image
@@ -450,7 +456,11 @@ def RP_global_heatmap(comparison):
 
     # Create the window with a static size
     window = sg.Window(
-        "Global Heatmap (Comparisons)", layout, resizable=True, finalize=True
+        "Global Heatmap (Comparisons)",
+        layout,
+        resizable=True,
+        finalize=True,
+        modal=True,
     )
 
     # Custom colormap: from #730000 (for -1) to #f1f2f2 (for 0) to #1a0099 (for 1)
@@ -623,6 +633,7 @@ def RP_global_distance(comparison):
         layout,
         resizable=True,
         finalize=True,
+        modal=True,
     )
 
     # Function to filter the data before plotting
@@ -777,7 +788,11 @@ def RP_class_heatmap(results):
 
     # Create the window with a static size
     window = sg.Window(
-        "Class Clustering Heatmap", layout, resizable=True, finalize=True
+        "Class Clustering Heatmap",
+        layout,
+        resizable=True,
+        finalize=True,
+        modal=True,
     )
 
     # Function to compute row-wise z-score

--- a/src/ccompass/SM.py
+++ b/src/ccompass/SM.py
@@ -116,7 +116,11 @@ def SM_exec(fract_data, fract_info, marker_list, key):
     ]
 
     window_SM = sg.Window(
-        "Marker profiles", layout_SM, finalize=True, size=(920, 520)
+        "Marker profiles",
+        layout_SM,
+        finalize=True,
+        size=(920, 520),
+        modal=True,
     )  # Adjust window width
 
     # Initial drawing

--- a/src/ccompass/TM.py
+++ b/src/ccompass/TM.py
@@ -123,7 +123,11 @@ def TM_exec(fract_data, fract_info, marker_list, key):
     ]
 
     window_TM = sg.Window(
-        "Marker correlations", layout_TM, finalize=True, size=(900, 650)
+        "Marker correlations",
+        layout_TM,
+        finalize=True,
+        size=(900, 650),
+        modal=True,
     )  # Increase window width
 
     # Initial drawing

--- a/src/ccompass/TPP.py
+++ b/src/ccompass/TPP.py
@@ -230,7 +230,7 @@ def create_window() -> sg.Window:
             ),
         ]
     ]
-    return sg.Window("Processing...", layout_TPP, size=(600, 110))
+    return sg.Window("Processing...", layout_TPP, size=(600, 110), modal=True)
 
 
 def start_total_proteome_processing(

--- a/src/ccompass/class_manager_dialog.py
+++ b/src/ccompass/class_manager_dialog.py
@@ -96,7 +96,7 @@ def _create_class_manager_window(
         ]
     ]
 
-    return sg.Window("Classes", layout_CM, size=(600, 400))
+    return sg.Window("Classes", layout_CM, size=(600, 400), modal=True)
 
 
 def show_class_manager_dialog(

--- a/src/ccompass/fractionation_parameters_dialog.py
+++ b/src/ccompass/fractionation_parameters_dialog.py
@@ -404,7 +404,10 @@ def _create_window(params_old) -> sg.Window:
     ]
 
     return sg.Window(
-        "Parameters for Pre-Processing", layout_PPMS, size=(800, 250)
+        "Parameters for Pre-Processing",
+        layout_PPMS,
+        size=(800, 250),
+        modal=True,
     )
 
 

--- a/src/ccompass/marker_parameters_dialog.py
+++ b/src/ccompass/marker_parameters_dialog.py
@@ -74,7 +74,7 @@ def _create_window(marker_params: dict[str, Any]) -> sg.Window:
         ],
     ]
 
-    return sg.Window("Marker Parameters", layout, size=(400, 100))
+    return sg.Window("Marker Parameters", layout, size=(400, 100), modal=True)
 
 
 def show_dialog(params_old: dict[str, Any]) -> dict[str, Any]:

--- a/src/ccompass/total_proteome_parameters_dialog.py
+++ b/src/ccompass/total_proteome_parameters_dialog.py
@@ -64,7 +64,7 @@ def _create_window(params_old) -> sg.Window:
         ],
     ]
 
-    return sg.Window("TP Parameters", layout_TPPM, size=(500, 100))
+    return sg.Window("TP Parameters", layout_TPPM, size=(500, 100), modal=True)
 
 
 def show_dialog(params_old) -> dict:

--- a/src/ccompass/training_parameters_dialog.py
+++ b/src/ccompass/training_parameters_dialog.py
@@ -220,7 +220,7 @@ def _create_window(nn_params: NeuralNetworkParametersModel) -> sg.Window:
         ],
     ]
 
-    return sg.Window("NN Parameters", layout, size=(470, 420))
+    return sg.Window("NN Parameters", layout, size=(470, 420), modal=True)
 
 
 def show_dialog(


### PR DESCRIPTION
So far, when a second window was open, one could still click buttons in the main window. However, the action was only performed once the secondary window was closed. This was awkward. Now, all secondary windows are switched to modal, preventing interaction with the primary window.

Closes #78.