### PR TITLE
Handle errors when loading sessions

### DIFF
--- a/src/ccompass/CCMPS.py
+++ b/src/ccompass/CCMPS.py
@@ -1462,12 +1462,26 @@ class MainController:
                     file_types=(("Numpy", "*.npy"),),
                 )
                 if filename:
-                    session_open(
-                        self.main_window,
-                        values,
-                        filename,
-                        model=self.model,
-                    )
+                    try:
+                        session_open(
+                            self.main_window,
+                            values,
+                            filename,
+                            model=self.model,
+                        )
+                    except Exception as e:
+                        print(f"An error occurred: {e}")
+                        import traceback
+
+                        # show error dialog with traceback
+                        traceback = traceback.format_exc()
+                        print(traceback)
+                        messagebox.showerror(
+                            "Error",
+                            "An error occurred while opening the session:\n\n"
+                            + str(e),
+                        )
+
                     # window_CCMPS['-marker_tpkey-'].Update(values = ['[IDENTIFIER]'] + tp_info.columns.tolist())
                     self.main_window["-marker_fractkey-"].Update(
                         values=["[IDENTIFIER]"] + list(self.model.fract_info),


### PR DESCRIPTION
So far, when an incompatible session was loaded, the program just crashed. Catch any errors and show an error dialog instead.

Closes #63