### PR TITLE
GHA: Run pre-commit hooks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,12 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y xvfb
         python -m pip install --upgrade pip
-        pip install -e .[test]
+        pip install -e .[test,dev]
+
+
+    - name: Run pre-commit checks
+      run: |
+        pre-commit run --all-files
 
     - name: Run tests
       run: |


### PR DESCRIPTION
Run linter and other checks via GitHub actions. Closes ##39.