### PR TITLE
Fix pandas FutureWarning / concat empty

### DIFF
--- a/src/ccompass/MOP.py
+++ b/src/ccompass/MOP.py
@@ -296,8 +296,12 @@ def upsampling(
                     profile_up.index = [name_up]
                     profile_up["class"] = [classname]
 
-                    class_up = pd.concat(
-                        [class_up, profile_up], axis=0, ignore_index=False
+                    class_up = (
+                        pd.concat(
+                            [class_up, profile_up], axis=0, ignore_index=False
+                        )
+                        if not class_up.empty
+                        else profile_up
                     )
 
                 fract_marker_up[condition] = pd.concat(


### PR DESCRIPTION
Get rid of this pandas warning due to concatenating empty dataframes:

```
C-COMPASS/src/ccompass/MOP.py:303: FutureWarning: The behavior of DataFrame concatenation with empty or all-NA entries is deprecated. In a future version, this will no longer exclude empty or all-NA columns when determining the result dtypes. To retain the old behavior, exclude the relevant entries before the concat operation.
  class_up = pd.concat(
```

Fixes #50.