### PR TITLE
Fix incorrect return values in FDP.py

### DIFF
--- a/src/ccompass/FDP.py
+++ b/src/ccompass/FDP.py
@@ -909,7 +909,13 @@ def FDP_exec(
             break
 
         if event_FDP == "--start--":
-            start_fract_data_processing(
+            (
+                data_ways,
+                std_ways,
+                intermediate_data,
+                protein_info,
+                conditions_trans,
+            ) = start_fract_data_processing(
                 window_FDP,
                 input_tables,
                 preparams,


### PR DESCRIPTION
Fixes a bug introduced in #88 / 113fd8f690f18a666acc903da7f100e14de80d3f. Return values were discarded by mistake.