### PR TITLE
Session serialization to zipped yaml/tsv

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -207,11 +207,22 @@ computer:
 1. Graphical User Interface (GUI)
 =================================
 
-C-COMPASS allows you to save and load your sessions via the main toolbar.
+C-COMPASS allows you to save and load your sessions via the main menu
+(:menuselection:`File --> Save As`).
+Saving after each significant step is recommended to avoid data loss.
+The session file, which includes all datasets, marker lists, settings,
+analyses, trainings, and statistics. These will be fully restored upon loading
+(:menuselection:`File --> Open`).
 
-A session can be saved as a NumPy (``.npy``) file, which includes all datasets,
-marker lists, settings, analyses, trainings, and statistics. These will be
-fully restored upon loading.
+There are currently two options for saving your session:
+
+* A **NumPy/pickly** (``.npy``) file. This is the fastest option.
+  However, those files will not necessarily work across different versions
+  of Python, C-COMPASS, numpy, or pandas.
+* A **zip** (``.ccompass``) file. This is significantly slower but more
+  reliable across different versions.
+
+The format can be chosen in the save dialog.
 
 2. Before training
 ==================

--- a/src/ccompass/core.py
+++ b/src/ccompass/core.py
@@ -786,7 +786,9 @@ class SessionModel(BaseModel):
             with open(temp_dir / "session.yaml", "w") as f:
                 yaml.safe_dump(self.model_dump(), f)
 
-            with zipfile.ZipFile(filepath, "w") as zipf:
+            with zipfile.ZipFile(
+                filepath, "w", compression=zipfile.ZIP_DEFLATED
+            ) as zipf:
                 for item in temp_dir.iterdir():
                     zipf.write(item, item.name)
 

--- a/src/ccompass/core.py
+++ b/src/ccompass/core.py
@@ -826,7 +826,6 @@ class SessionModel(BaseModel):
             def series_constructor(loader, node):
                 """Custom YAML constructor for pandas Series."""
                 file_path = temp_dir / loader.construct_scalar(node)
-                print(file_path, type(file_path))
                 df = pd.read_csv(
                     file_path,
                     sep="\t",
@@ -835,7 +834,6 @@ class SessionModel(BaseModel):
                     float_precision="round_trip",
                 )
                 assert df.shape[1] == 1
-                print(df.iloc[:, 0], type(df.iloc[:, 0]))
                 return df.iloc[:, 0]
 
             def tuple_constructor(loader, node):

--- a/src/ccompass/main_gui.py
+++ b/src/ccompass/main_gui.py
@@ -1583,7 +1583,10 @@ class MainController:
             "Open Session",
             initial_folder=str(self.app_settings.last_session_dir),
             no_window=True,
-            file_types=(("Numpy", "*.npy"),),
+            file_types=(
+                ("Numpy", "*.npy"),
+                ("C-COMPASS zip", "*.ccompass"),
+            ),
         )
         if not filename:
             return
@@ -1621,7 +1624,10 @@ class MainController:
         filename = sg.popup_get_file(
             "Save Session",
             no_window=True,
-            file_types=(("Numpy", "*.npy"),),
+            file_types=(
+                ("Numpy", "*.npy"),
+                ("C-COMPASS zip", "*.ccompass"),
+            ),
             save_as=True,
             initial_folder=str(self.app_settings.last_session_dir),
         )
@@ -1633,7 +1639,10 @@ class MainController:
         self.app_settings.save()
 
         with wait_cursor(self.main_window):
-            self.model.to_numpy(filename)
+            if filename.endswith(".ccompass"):
+                self.model.to_zip(filename)
+            else:
+                self.model.to_numpy(filename)
 
         self._update_recent_files()
 
@@ -2250,7 +2259,10 @@ def marker_setclass(values, marker_sets):
 def session_open(window: sg.Window, filename: str, model: SessionModel):
     """Read session data from file and update the window."""
     # Update session data
-    tmp_session = SessionModel.from_numpy(filename)
+    if filename.endswith(".ccompass"):
+        tmp_session = SessionModel.from_zip(filename)
+    else:
+        tmp_session = SessionModel.from_numpy(filename)
     model.reset(tmp_session)
 
     # update GUI

--- a/src/ccompass/main_gui.py
+++ b/src/ccompass/main_gui.py
@@ -1639,7 +1639,7 @@ class MainController:
         self.app_settings.save()
 
         with wait_cursor(self.main_window):
-            if filename.endswith(".ccompass"):
+            if str(filename).endswith(".ccompass"):
                 self.model.to_zip(filename)
             else:
                 self.model.to_numpy(filename)

--- a/tests/test_full_analysis.py
+++ b/tests/test_full_analysis.py
@@ -2,6 +2,7 @@ import os
 from pathlib import Path
 
 import numpy as np
+from test_session_model import assert_session_equal
 
 from ccompass._testing.synthetic_data import (
     SyntheticDataConfig,
@@ -201,3 +202,13 @@ def test_full():
 
     ...
     sess.to_numpy(Path(__file__).parent / "session_test_full.npy")
+    sess.to_zip(Path(__file__).parent / "session_test_full.ccompass")
+
+    sess2 = SessionModel.from_numpy(
+        Path(__file__).parent / "session_test_full.npy"
+    )
+    assert_session_equal(sess, sess2)
+    sess2 = SessionModel.from_zip(
+        Path(__file__).parent / "session_test_full.ccompass"
+    )
+    assert_session_equal(sess, sess2)

--- a/tests/test_session_model.py
+++ b/tests/test_session_model.py
@@ -22,7 +22,7 @@ def test_serialization():
     assert_session_equal(session, session2)
 
 
-def assert_equal(obj1, obj2):
+def assert_equal(obj1, obj2) -> None:
     """Check if two objects are equal."""
     if isinstance(obj1, pydantic.BaseModel):
         assert isinstance(obj2, pydantic.BaseModel)
@@ -37,9 +37,16 @@ def assert_equal(obj1, obj2):
         for i in range(len(obj1)):
             assert_equal(obj1[i], obj2[i])
     elif isinstance(obj1, pd.DataFrame):
+        assert isinstance(obj2, pd.DataFrame)
+        if obj1.empty and obj2.empty:
+            # if both are empty, we don't compare columns
+            return
         pd.testing.assert_frame_equal(obj1, obj2, check_dtype=False)
     elif isinstance(obj1, pd.Series):
-        pd.testing.assert_series_equal(obj1, obj2)
+        assert isinstance(obj2, pd.Series), f"{obj1} != {obj2}"
+        pd.testing.assert_series_equal(
+            obj1, obj2, atol=1e-14, rtol=1e-14, check_dtype=False
+        )
     elif isinstance(obj1, np.ndarray):
         np.testing.assert_almost_equal(obj1, obj2)
     elif isinstance(obj1, float) and pd.isna(obj1):

--- a/tests/test_session_model.py
+++ b/tests/test_session_model.py
@@ -3,7 +3,9 @@
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+import numpy as np
 import pandas as pd
+import pydantic
 
 from ccompass.main_gui import SessionModel
 
@@ -22,6 +24,11 @@ def test_serialization():
 
 def assert_equal(obj1, obj2):
     """Check if two objects are equal."""
+    if isinstance(obj1, pydantic.BaseModel):
+        assert isinstance(obj2, pydantic.BaseModel)
+        assert_equal(obj1.model_dump(), obj2.model_dump())
+        return
+
     if isinstance(obj1, dict):
         for key in obj1:
             assert key in obj2
@@ -33,6 +40,8 @@ def assert_equal(obj1, obj2):
         pd.testing.assert_frame_equal(obj1, obj2, check_dtype=False)
     elif isinstance(obj1, pd.Series):
         pd.testing.assert_series_equal(obj1, obj2)
+    elif isinstance(obj1, np.ndarray):
+        np.testing.assert_almost_equal(obj1, obj2)
     elif isinstance(obj1, float) and pd.isna(obj1):
         assert pd.isna(obj2)
     else:

--- a/tests/test_session_model.py
+++ b/tests/test_session_model.py
@@ -30,7 +30,11 @@ def assert_equal(obj1, obj2):
         for i in range(len(obj1)):
             assert_equal(obj1[i], obj2[i])
     elif isinstance(obj1, pd.DataFrame):
-        pd.testing.assert_frame_equal(obj1, obj2)
+        pd.testing.assert_frame_equal(obj1, obj2, check_dtype=False)
+    elif isinstance(obj1, pd.Series):
+        pd.testing.assert_series_equal(obj1, obj2)
+    elif isinstance(obj1, float) and pd.isna(obj1):
+        assert pd.isna(obj2)
     else:
         assert obj1 == obj2
 
@@ -42,3 +46,16 @@ def assert_session_equal(session, session2):
         assert_equal(getattr(session, attr), getattr(session2, attr))
     for attr in session2.__dict__:
         assert attr in session.__dict__
+
+
+def test_serialize_zip():
+    """Test serialization of SessionModel to zip."""
+    session = SessionModel()
+
+    # round trip
+    with TemporaryDirectory() as tempdir:
+        fpath = Path(tempdir, "session.zip")
+        session.to_zip(fpath)
+        session2 = SessionModel.from_zip(fpath)
+
+    assert_session_equal(session, session2)


### PR DESCRIPTION
Serialize session data to a zipped yaml file and tsv files instead of pickling, so the data is portable across different versions of Python and other dependencies.

Added as an optional, more portable, but significantly slower alternative to numpy/pickle.

Closes #24.