### PR TITLE
Remove `fract_intermediate` and `tp_intermediate`

### DIFF
--- a/src/ccompass/FDP.py
+++ b/src/ccompass/FDP.py
@@ -525,10 +525,6 @@ def start_fract_data_processing(
         "class": copy.deepcopy(dataset),
         "vis": copy.deepcopy(dataset),
     }
-    intermediate_data = {
-        "[0] class_abs": copy.deepcopy(data_ways["class"]),
-        "[0] vis_abs": copy.deepcopy(data_ways["vis"]),
-    }
 
     # ---------------------------------------------------------------------
     logger.info("converting dataset...")
@@ -539,9 +535,6 @@ def start_fract_data_processing(
 
     for way in data_ways:
         data_ways[way] = remove_zeros(data_ways[way])
-        intermediate_data[f"[1] {way}_nozeros1"] = copy.deepcopy(
-            data_ways[way]
-        )
 
     # ---------------------------------------------------------------------
     logger.info("pre-scaling...")
@@ -558,9 +551,6 @@ def start_fract_data_processing(
                 window,
                 progress,
             )
-        intermediate_data[f"[2] {way}_prescaled"] = copy.deepcopy(
-            data_ways[way]
-        )
 
     # ---------------------------------------------------------------------
     logger.info("filtering by missing fractions...")
@@ -577,10 +567,6 @@ def start_fract_data_processing(
                 window,
                 progress,
             )
-    intermediate_data["[3] class_f_missing"] = copy.deepcopy(
-        data_ways["class"]
-    )
-    intermediate_data["[3] vis_f_missing"] = copy.deepcopy(data_ways["vis"])
 
     # ---------------------------------------------------------------------
     logger.info("finding IDs...")
@@ -596,8 +582,6 @@ def start_fract_data_processing(
             window,
             progress,
         )
-    intermediate_data["[4] class_f_count"] = copy.deepcopy(data_ways["class"])
-    intermediate_data["[4] vis_f_count"] = copy.deepcopy(data_ways["vis"])
 
     # ---------------------------------------------------------------------
     logger.info("detecting samples...")
@@ -629,9 +613,6 @@ def start_fract_data_processing(
             data_ways[way] = combine_concat(data_ways[way], window)
         elif preparams[way]["combination"] == "separate":
             pass
-        intermediate_data[f"[6] {way}_combined"] = copy.deepcopy(
-            data_ways[way]
-        )
 
     # ---------------------------------------------------------------------
     logger.info("post-scaling...")
@@ -648,10 +629,6 @@ def start_fract_data_processing(
                 window,
                 progress,
             )
-    intermediate_data["[7] class_postscaled"] = copy.deepcopy(
-        data_ways["class"]
-    )
-    intermediate_data["[7] vis_postscaled"] = copy.deepcopy(data_ways["vis"])
 
     # ---------------------------------------------------------------------
     logger.info("removing zeros...")
@@ -663,8 +640,6 @@ def start_fract_data_processing(
     for way in data_ways:
         if preparams[way]["zeros"]:
             data_ways[way] = remove_zeros(data_ways[way])
-    intermediate_data["[8] class_nozeros2"] = copy.deepcopy(data_ways["class"])
-    intermediate_data["[8] vis_nozeros2"] = copy.deepcopy(data_ways["vis"])
 
     # ---------------------------------------------------------------------
     logger.info("calculating outer correlations...")
@@ -697,7 +672,6 @@ def start_fract_data_processing(
     return (
         data_ways,
         std_ways,
-        intermediate_data,
         protein_info,
         conditions,
     )
@@ -780,7 +754,6 @@ def FDP_exec(
     identifiers: dict[str, str],
     data_ways: dict[str, dict[str, pd.DataFrame]],
     std_ways: dict[str, dict[str, pd.DataFrame]],
-    intermediate_data: dict[str, dict[str, dict[str, pd.DataFrame]]],
     protein_info: dict[str, pd.DataFrame],
     conditions_trans: list[str],
     fract_indata: dict[str, pd.DataFrame],
@@ -807,7 +780,6 @@ def FDP_exec(
             (
                 data_ways,
                 std_ways,
-                intermediate_data,
                 protein_info,
                 conditions_trans,
             ) = start_fract_data_processing(
@@ -824,7 +796,6 @@ def FDP_exec(
     return (
         data_ways,
         std_ways,
-        intermediate_data,
         protein_info,
         conditions_trans,
     )

--- a/src/ccompass/core.py
+++ b/src/ccompass/core.py
@@ -336,9 +336,6 @@ class SessionModel(BaseModel):
     fract_std: dict[
         Literal["class", "vis"], dict[ConditionId, pd.DataFrame]
     ] = {"class": {}, "vis": {}}
-    #: ??
-    #  *something* => "{condition}" => "Rep.{replicate}" => DataFrame
-    fract_intermediate: dict[str, dict[str, dict[str, pd.DataFrame]]] = {}
     #: Identifier column of each fractionation data table:
     #   filepath => column id
     fract_identifiers: dict[Filepath, str] = {}
@@ -492,7 +489,6 @@ class SessionModel(BaseModel):
     def reset_fract(self):
         self.fract_data = {"class": {}, "vis": {}}
         self.fract_std = {"class": {}, "vis": {}}
-        self.fract_intermediate = {}
         self.fract_info = {}
         self.fract_conditions = []
 

--- a/src/ccompass/core.py
+++ b/src/ccompass/core.py
@@ -384,9 +384,6 @@ class SessionModel(BaseModel):
     #  One DataFrame for each condition containing all replicates
     #  (column names are "{condition}_Rep.{replicate}")
     tp_data: dict[ConditionReplicate, pd.DataFrame] = {}
-    #: ??
-    #  *something* => "{condition}" => DataFrame
-    tp_intermediate: dict[str, dict[str, pd.DataFrame]] = {}
     #: Identifier column for the total proteome: filepath => column id
     tp_identifiers: dict[Filepath, str] = {}
     #: ??
@@ -494,7 +491,6 @@ class SessionModel(BaseModel):
 
     def reset_tp(self):
         self.tp_data = {}
-        self.tp_intermediate = {}
         self.tp_info = pd.DataFrame()
         self.tp_conditions = []
         self.tp_icorr = {}

--- a/src/ccompass/main_gui.py
+++ b/src/ccompass/main_gui.py
@@ -1108,7 +1108,6 @@ class MainController:
                     (
                         self.model.fract_data,
                         self.model.fract_std,
-                        self.model.fract_intermediate,
                         self.model.fract_info,
                         self.model.fract_conditions,
                     ) = FDP_exec(
@@ -1117,7 +1116,6 @@ class MainController:
                         self.model.fract_identifiers,
                         self.model.fract_data,
                         self.model.fract_std,
-                        self.model.fract_intermediate,
                         self.model.fract_info,
                         self.model.fract_conditions,
                         self.model.fract_indata,

--- a/src/ccompass/main_gui.py
+++ b/src/ccompass/main_gui.py
@@ -1207,7 +1207,6 @@ class MainController:
 
                     (
                         self.model.tp_data,
-                        self.model.tp_intermediate,
                         self.model.tp_info,
                         self.model.tp_conditions,
                         self.model.tp_icorr,
@@ -1216,7 +1215,6 @@ class MainController:
                         self.model.tp_tables,
                         self.model.tp_preparams,
                         self.model.tp_identifiers,
-                        self.model.tp_intermediate,
                         self.model.tp_info,
                         self.model.tp_icorr,
                         self.model.tp_indata,


### PR DESCRIPTION
The intermediate results in `fract_intermediate` and `tp_intermediate` weren't used anywhere. Let's avoid the extra time and memory.

Closes #141 