### PR TITLE
Spawn on macOS

### DIFF
--- a/src/ccompass/MOP.py
+++ b/src/ccompass/MOP.py
@@ -172,9 +172,10 @@ def MOP_exec(
     window.set_cursor("watch")
 
     # run actual prediction in a separate thread to allow for progress updates
-    manager = mp.Manager()
+    ctx = get_mp_ctx()
+    manager = ctx.Manager()
     progress_queue = manager.Queue()
-    result_queue = mp.Queue()
+    result_queue = ctx.Queue()
     worker_thread = threading.Thread(
         target=multi_organelle_prediction,
         args=(
@@ -187,6 +188,9 @@ def MOP_exec(
             result_queue,
         ),
         daemon=True,
+    )
+    logger.info(
+        f"Starting multi-organelle prediction ({max_processes} procs)..."
     )
     worker_thread.start()
 
@@ -204,6 +208,7 @@ def MOP_exec(
 
     worker_thread.join()
     window.close()
+    logger.info("Finished multi-organelle prediction.")
 
     return result
 

--- a/src/ccompass/_utils.py
+++ b/src/ccompass/_utils.py
@@ -94,7 +94,7 @@ def stdout_to_logger(logger: logging.Logger, log_level=logging.INFO):
 
 def get_mp_ctx() -> multiprocessing.context.BaseContext:
     """Get the multiprocessing context."""
-    if platform.system() == "Windows":
+    if platform.system() in ("Windows", "Darwin"):
         return multiprocessing.get_context("spawn")
     else:
         return multiprocessing.get_context("forkserver")

--- a/tests/test_sample_data.py
+++ b/tests/test_sample_data.py
@@ -231,6 +231,7 @@ def test_save_sample_data_session():
     """
     sess = get_sample_session_input()
     sess.to_numpy(Path(__file__).parent / "_sample_data_input.npy")
+    sess.to_zip(Path(__file__).parent / "_sample_data_input.ccompass")
 
 
 def test_fdp():


### PR DESCRIPTION
Use `spawn` multiprocessing method on macOS, avoiding multithreading issues with Tkinter (` File "tkinter/__init__.py", line 414, in __del__ RuntimeError: main thread is not in main loop`).